### PR TITLE
Feat/fix oz code inspector issues

### DIFF
--- a/packages/contracts/test/helpers/DeploymentHelper.sol
+++ b/packages/contracts/test/helpers/DeploymentHelper.sol
@@ -81,12 +81,14 @@ contract DeploymentHelper is Test {
         SimpleWallet simpleWalletImpl = new SimpleWallet();
         ERC1967Proxy simpleWalletProxy = new ERC1967Proxy(
             address(simpleWalletImpl),
-            abi.encodeWithSelector(
-                simpleWalletImpl.initialize.selector,
-                signer,
-                address(verifier),
-                address(dkim),
-                address(emailAuthImpl)
+            abi.encodeCall(
+                simpleWalletImpl.initialize,
+                (
+                    signer,
+                    address(verifier),
+                    address(dkim),
+                    address(emailAuthImpl)
+                )
             )
         );
         simpleWallet = SimpleWallet(payable(address(simpleWalletProxy)));

--- a/packages/contracts/test/helpers/SimpleWallet.sol
+++ b/packages/contracts/test/helpers/SimpleWallet.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.12;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {EmailAccountRecovery} from "../../src/EmailAccountRecovery.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 contract SimpleWallet is OwnableUpgradeable, EmailAccountRecovery {
     enum GuardianStatus {
@@ -54,7 +55,7 @@ contract SimpleWallet is OwnableUpgradeable, EmailAccountRecovery {
         uint256 amount
     ) public onlyNotRecoveringOwner {
         require(address(this).balance >= amount, "insufficient balance");
-        payable(to).transfer(amount);
+        Address.sendValue(payable(to), amount);
     }
 
     function withdraw(uint256 amount) public onlyNotRecoveringOwner {

--- a/packages/contracts/test/helpers/StructHelper.sol
+++ b/packages/contracts/test/helpers/StructHelper.sol
@@ -34,10 +34,7 @@ contract StructHelper is DeploymentHelper {
 
         vm.mockCall(
             address(verifier),
-            abi.encodeWithSelector(
-                Verifier.verifyEmailProof.selector,
-                emailProof
-            ),
+            abi.encodeCall(Verifier.verifyEmailProof, (emailProof)),
             abi.encode(true)
         );
     }


### PR DESCRIPTION
I checked the contract vulnerabilities using OpenZeppelin Defender Code Inspector.
There are some issues, 1 high issue and 8 low issues.

High

1. Boolean literals used in complex expressions or as conditions

```
isDKIMPublicKeyHashValid in ECDSAOwnedDKIMRegistry
emailAuthMsg.proof.isCodeExist in EmailAuthMsg struct
emailAuthMsg.proof.emailNullifier in EmailAuthMsg struct
timestampCheckEnabled in EmailAuth
verifyEmailProof in Verifier
```

To avoid misuse of a Boolean literal, ensure it aligns with intended behavior and is well documented.

-> Because we are using these values and functions in a clear usage, it can be ignored.

Low

1. `transfer` and `send` calls are no longer considered best practice -> Fixed
3. Pragma statement spans several minor versions of solidity -> can be ignored, it's relevant in Groth16Verifier.sol
4. Unsafe abi encoding -> Fixed
5. Different pragma directives are used -> can be ignored, it's relevant in Groth16Verifier.sol
6. Floating pragma -> can be ignored?
7. Missing docstrings -> can be ignored, we only have that in public or external functions
8. Missing return statement -> can be ignored, it's relevant in Groth16Verifier.sol
9. External call failure checks are missing -> can be ignored, it's relevant in Groth16Verifier.sol