### PR TITLE
Feat/fix foundry version

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1.2.0
+        with:
+          version: nightly-3e9385b65d5ff502095c7896aab6042127548c34
 
       - name: Run tests
         working-directory: packages/contracts

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -10,6 +10,7 @@ yarn install
 ## Build and Test
 
 Make sure you have [Foundry](https://github.com/foundry-rs/foundry) installed
+Currently, the latest version is not working in some test cases, please use nightly-3e9385b65d5ff502095c7896aab6042127548c34
 
 Build the contracts using the below command.
 


### PR DESCRIPTION
Currently, the latest foundry version is not working in some test cases, we should use nightly-3e9385b65d5ff502095c7896aab6042127548c34