### PR TITLE
Feat/latest foundy zksync

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -192,49 +192,28 @@ It also provides the following entry functions with their default implementation
 You should use foundry-zksync, the installation process is following URL.
 https://github.com/matter-labs/foundry-zksync
 
-Current version foundry-zksync is forge 0.0.2 (f505a53 2024-06-27T00:23:42.073876000Z).
+Current version foundry-zksync is forge 0.0.2 (6e1c282 2024-07-01T00:26:02.947919000Z)
 
-They can't use solc 0.8.25, so you should set appreciate solc version in foundry.toml.
-For ex. 
-
-```
-solc = "0.8.23"
-```
-
-Also the current foundry-zksync does not work correctly if your svm has 0.8.25 installed.
-In that case, please do the following:
-
-For Apple Silicon
+Now foundry-zksync supports solc 0.8.25, but it won't be automatically downloaded by foundry-zksync.
+First you should compile our contracts with foundry, and then install foundry-zksync.
 
 ```
-rm -rf  ~/Library/Application\ Support/svm/0.8.25
-```
+# Install foundry
+foundryup
 
-Or you can use docker too.
+cd packages/contracts
+yarn build
 
-```
-docker run -d -it -v $PWD:$PWD --name zksync-development --platform linux/amd64 ubuntu
-docker exec -it zksync-development bash
-```
+# Check if you have already had 0.8.25
+ls -l /Users/{USER_NAME}/Library/Application\ Support/svm/0.8.25
 
-In the docker container, you should execute following commands.
-
-```
-apt update
-apt -y install git curl nodejs npm
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-curl -L https://foundry.paradigm.xyz | bash
-source ~/.bashrc
-git clone https://github.com/matter-labs/foundry-zksync.git
-cd foundry-zksync
+# Install foundry-zksync
+cd YOUR_FOUNDRY_ZKSYNC_DIR
 chmod +x ./install-foundry-zksync
 ./install-foundry-zksync
-cd /Users/wataru_shinohara/GitHub/zkemail/ether-email-auth
-yarn
-cd packages/contracts
 ```
 
-Also, there are the problem with foundy-zksync. They can't resolve contracts in monorepo's node_modules.
+In addition, there are the problem with foundy-zksync. Currently they can't resolve contracts in monorepo's node_modules.
 
 https://github.com/matter-labs/foundry-zksync/issues/411
 
@@ -273,8 +252,8 @@ Deployer: 0xfB1CcCBDa2C41a77cDAC448641006Fc7fcf1f3b9
 Deployed to: 0x91cc0f0A227b8dD56794f9391E8Af48B40420A0b
 Transaction hash: 0x4f94ab71443d01988105540c3abb09ed66f8af5d0bb6a88691e2dafa88b3583d
 [⠢] Compiling...
-[⠃] Compiling 68 files with 0.8.23
-[⠆] Solc 0.8.23 finished in 12.20s
+[⠃] Compiling 68 files with 0.8.25
+[⠆] Solc 0.8.25 finished in 12.20s
 Compiler run successful!
 Deployer: 0xfB1CcCBDa2C41a77cDAC448641006Fc7fcf1f3b9
 Deployed to: 0x981E3Df952358A57753C7B85dE7949Da4aBCf54A
@@ -311,6 +290,8 @@ Even if the contract size is fine for EVM, it may exceed the bytecode size limit
 Therefore, EmailAccountRecovery.t.sol has been splited.
 
 Currently some test cases are not work correctly because there is a issue about missing libraries.
+
+https://github.com/matter-labs/foundry-zksync/issues/382
 
 Failing test cases are here.
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -192,7 +192,8 @@ It also provides the following entry functions with their default implementation
 You should use foundry-zksync, the installation process is following URL.
 https://github.com/matter-labs/foundry-zksync
 
-Current version foundry-zksync is forge 0.0.2 (13497a5 2024-05-16T00:24:48.304138000Z)
+Current version foundry-zksync is forge 0.0.2 (f505a53 2024-06-27T00:23:42.073876000Z).
+
 They can't use solc 0.8.25, so you should set appreciate solc version in foundry.toml.
 For ex. 
 
@@ -291,12 +292,12 @@ libraries = ["{PROJECT_DIR}/packages/contracts/src/libraries/DecimalUtils.sol:De
 Incidentally, the above line already exists in `foundy.toml` with it commented out, if you uncomment it by replacing `{PROJECT_DIR}` with the appropriate path, it will also work.
 
 About Create2, `L2ContractHelper.computeCreate2Address` should be used.
-And `type(ERC1967Proxy).creationCode` doesn't work correctly.
+And `type(ERC1967Proxy).creationCode` doesn't work correctly in zkSync.
 We need to hardcode the `type(ERC1967Proxy).creationCode` to bytecodeHash.
 Perhaps that is different value in each compiler version.
 
 You should replace the following line to the correct hash.
-packages/contracts/src/EmailAccountRecovery.sol:L94 
+packages/contracts/src/EmailAccountRecovery.sol:L119
 
 See, test/ComputeCreate2Address.t.sol
 
@@ -313,13 +314,17 @@ Currently some test cases are not work correctly because there is a issue about 
 
 Failing test cases are here.
 
+EmailAuthWithUserOverrideableDkim.t.sol
+
+- testAuthEmail()
+
+EmailAuth.t.sol
+
 - testAuthEmail()
 - testExpectRevertAuthEmailEmailNullifierAlreadyUsed() 
 - testExpectRevertAuthEmailInvalidEmailProof()
 - testExpectRevertAuthEmailInvalidSubject()
 - testExpectRevertAuthEmailInvalidTimestamp()
-- testIsValidSignature()
-- testIsValidSignatureReturnsFalse()
 
 # For integration testing
 

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -10,7 +10,8 @@ fs_permissions = [
     { access = "read", path = "./test/build_integration" },
     { access = "read", path = "./zkout/ERC1967Proxy.sol/ERC1967Proxy.json" },
 ]
-solc = "0.8.23"
+
+solc = "0.8.25"
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
 

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -8,7 +8,7 @@ optimizer-runs = 20_000
 fs_permissions = [
     { access = "read", path = "./artifacts/WETH9.sol/WETH9.json" },
     { access = "read", path = "./test/build_integration" },
-    { access = "read", path = "./zkout/ERC1967Proxy.sol/artifacts.json" },
+    { access = "read", path = "./zkout/ERC1967Proxy.sol/ERC1967Proxy.json" },
 ]
 solc = "0.8.23"
 

--- a/packages/contracts/src/EmailAccountRecovery.sol
+++ b/packages/contracts/src/EmailAccountRecovery.sol
@@ -208,10 +208,6 @@ abstract contract EmailAccountRecovery {
             recoveredAccount,
             emailAuthMsg.proof.accountSalt
         );
-        // require(
-        //     address(guardian).code.length == 0,
-        //     "guardian is already deployed"
-        // );
         uint templateId = computeAcceptanceTemplateId(templateIdx);
         require(templateId == emailAuthMsg.templateId, "invalid template id");
         require(emailAuthMsg.proof.isCodeExist == true, "isCodeExist is false");

--- a/packages/contracts/src/EmailAccountRecovery.sol
+++ b/packages/contracts/src/EmailAccountRecovery.sol
@@ -116,7 +116,7 @@ abstract contract EmailAccountRecovery {
                     address(this),
                     accountSalt,
                     bytes32(
-                        0x010000830a636831d3678f83275e3c9257b482d6ee5dc76d741ced984134f9de
+                        0x01000083f30da117496892e53895c30802e6708d8cdbad6233c6d4ec63a96ebf
                     ),
                     keccak256(
                         abi.encode(

--- a/packages/contracts/test/ComputeCreate2Address.t.sol
+++ b/packages/contracts/test/ComputeCreate2Address.t.sol
@@ -27,11 +27,11 @@ contract ComputeCreate2AddressTest is StructHelper {
         // See the example code
         // https://github.com/matter-labs/foundry-zksync/blob/13497a550e4a097c57bec7430435ab810a6d10fc/zk-tests/src/Contracts.t.sol#L195
         string memory artifact = vm.readFile(
-            "zkout/ERC1967Proxy.sol/artifacts.json"
+            "zkout/ERC1967Proxy.sol/ERC1967Proxy.json"
         );
         bytes32 bytecodeHash = vm.parseJsonBytes32(
             artifact,
-            '.contracts.["../../node_modules/@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol"].ERC1967Proxy.hash'
+            '.hash'
         );
         console.log("bytecodeHash");
         console.logBytes32(bytes32(bytecodeHash));

--- a/packages/contracts/test/helpers/DeploymentHelper.sol
+++ b/packages/contracts/test/helpers/DeploymentHelper.sol
@@ -49,7 +49,7 @@ contract DeploymentHelper is Test {
         if (block.chainid == 300) {
             guardian = address(0x5BD638D229a146696d03b6EedE99c398bDCb6218);
         } else {
-            guardian = address(0x525e666Db4318258d24d63D20Cf40210C2F75Ca5);
+            guardian = address(0x32Bb4db794aCa503933beA15ceD66624c4E7c24F);
         }
 
         vm.startPrank(deployer);

--- a/packages/contracts/test/helpers/DeploymentHelper.sol
+++ b/packages/contracts/test/helpers/DeploymentHelper.sol
@@ -47,7 +47,7 @@ contract DeploymentHelper is Test {
         // For zkSync computeEmailAuthAddress uses L2ContractHelper.computeCreate2Address
         // The gardian address should be different from other EVM chains
         if (block.chainid == 300) {
-            guardian = address(0x4110796d50E5a4f51E626B00c38af39d236Ec8b9);
+            guardian = address(0x5BD638D229a146696d03b6EedE99c398bDCb6218);
         } else {
             guardian = address(0xfB1f91113157135BA8a461489c1Ae92Fb681beFF);
         }

--- a/packages/contracts/test/helpers/DeploymentHelper.sol
+++ b/packages/contracts/test/helpers/DeploymentHelper.sol
@@ -49,7 +49,7 @@ contract DeploymentHelper is Test {
         if (block.chainid == 300) {
             guardian = address(0x5BD638D229a146696d03b6EedE99c398bDCb6218);
         } else {
-            guardian = address(0xfB1f91113157135BA8a461489c1Ae92Fb681beFF);
+            guardian = address(0x525e666Db4318258d24d63D20Cf40210C2F75Ca5);
         }
 
         vm.startPrank(deployer);


### PR DESCRIPTION
This PR supports solc 0.8.25 with foundry-zksync.
Accordingly, some code related to the test case has been changed.

1. Change the logic to retrieve byte code hash
2. Change the guardian address in test helper