### PR TITLE
Set solc = 0.8.26 and zksolc = 1.5.0.

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -194,7 +194,7 @@ https://github.com/matter-labs/foundry-zksync
 
 Current version foundry-zksync is forge 0.0.2 (6e1c282 2024-07-01T00:26:02.947919000Z)
 
-Now foundry-zksync supports solc 0.8.25, but it won't be automatically downloaded by foundry-zksync.
+Now foundry-zksync supports solc 0.8.26, but it won't be automatically downloaded by foundry-zksync.
 First you should compile our contracts with foundry, and then install foundry-zksync.
 
 ```
@@ -204,13 +204,18 @@ foundryup
 cd packages/contracts
 yarn build
 
-# Check if you have already had 0.8.25
-ls -l /Users/{USER_NAME}/Library/Application\ Support/svm/0.8.25
+# Check if you have already had 0.8.26
+ls -l /Users/{USER_NAME}/Library/Application\ Support/svm/0.8.26
 
 # Install foundry-zksync
 cd YOUR_FOUNDRY_ZKSYNC_DIR
 chmod +x ./install-foundry-zksync
 ./install-foundry-zksync
+
+# Install zksolc-bin 1.5.0 manually
+# Download https://github.com/matter-labs/zksolc-bin/releases/tag/v1.5.0
+chmod a+x {BINARY_NAME}
+mv {BINARY_NAME} ~/.zksync/.
 ```
 
 In addition, there are the problem with foundy-zksync. Currently they can't resolve contracts in monorepo's node_modules.
@@ -252,8 +257,8 @@ Deployer: 0xfB1CcCBDa2C41a77cDAC448641006Fc7fcf1f3b9
 Deployed to: 0x91cc0f0A227b8dD56794f9391E8Af48B40420A0b
 Transaction hash: 0x4f94ab71443d01988105540c3abb09ed66f8af5d0bb6a88691e2dafa88b3583d
 [⠢] Compiling...
-[⠃] Compiling 68 files with 0.8.25
-[⠆] Solc 0.8.25 finished in 12.20s
+[⠃] Compiling 68 files with 0.8.26
+[⠆] Solc 0.8.26 finished in 12.20s
 Compiler run successful!
 Deployer: 0xfB1CcCBDa2C41a77cDAC448641006Fc7fcf1f3b9
 Deployed to: 0x981E3Df952358A57753C7B85dE7949Da4aBCf54A

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -11,7 +11,7 @@ fs_permissions = [
     { access = "read", path = "./zkout/ERC1967Proxy.sol/ERC1967Proxy.json" },
 ]
 
-solc = "0.8.25"
+solc = "0.8.26"
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
 
@@ -31,9 +31,11 @@ mainnet = "${MAINNET_RPC_URL}"
 sepolia = { key = "${ETHERSCAN_API_KEY}" }
 mainnet = { key = "${ETHERSCAN_API_KEY}" }
 
-[profile.zksync]
+[profile.default.zksync] 
 src = 'src'
-libs = ["../../node_modules", "lib"]
+libs = ["node_modules", "lib"]
 fallback_oz = true
 is_system = false
 mode = "3"
+
+zksolc = "1.5.0"

--- a/packages/contracts/src/EmailAccountRecovery.sol
+++ b/packages/contracts/src/EmailAccountRecovery.sol
@@ -116,7 +116,7 @@ abstract contract EmailAccountRecovery {
                     address(this),
                     accountSalt,
                     bytes32(
-                        0x01000083f30da117496892e53895c30802e6708d8cdbad6233c6d4ec63a96ebf
+                        0x0100007934a4ec31a894c66e0d97810c45cade119a9dcba3f02c341c06aa8684
                     ),
                     keccak256(
                         abi.encode(

--- a/packages/contracts/test/helpers/DeploymentHelper.sol
+++ b/packages/contracts/test/helpers/DeploymentHelper.sol
@@ -47,9 +47,9 @@ contract DeploymentHelper is Test {
         // For zkSync computeEmailAuthAddress uses L2ContractHelper.computeCreate2Address
         // The gardian address should be different from other EVM chains
         if (block.chainid == 300) {
-            guardian = address(0x5BD638D229a146696d03b6EedE99c398bDCb6218);
+            guardian = address(0x894B4AeFE4c0a145ecac5E433918F0C4BC212C48);
         } else {
-            guardian = address(0x32Bb4db794aCa503933beA15ceD66624c4E7c24F);
+            guardian = address(0x4F1102177DD38b7ab19207c9846172B0c30FEAD5);
         }
 
         vm.startPrank(deployer);


### PR DESCRIPTION
This PR relates to the below issue.
https://github.com/matter-labs/foundry-zksync/issues/459

This PR supports solc 0.8.26 and also improves the compile speed and the memory usage.