### PR TITLE
Remove TODO: from EmailAccountRecovery.sol.

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -299,7 +299,7 @@ We need to hardcode the `type(ERC1967Proxy).creationCode` to bytecodeHash.
 Perhaps that is different value in each compiler version.
 
 You should replace the following line to the correct hash.
-packages/contracts/src/EmailAccountRecovery.sol:L119
+packages/contracts/src/EmailAccountRecovery.sol:L111
 
 See, test/ComputeCreate2Address.t.sol
 

--- a/packages/contracts/src/EmailAccountRecovery.sol
+++ b/packages/contracts/src/EmailAccountRecovery.sol
@@ -108,7 +108,7 @@ abstract contract EmailAccountRecovery {
     ) public view returns (address) {
         // If on zksync, we use L2ContractHelper.computeCreate2Address
         if (block.chainid == 324 || block.chainid == 300) {
-            // TODO: The bytecodeHash is hardcoded here because type(ERC1967Proxy).creationCode doesn't work on eraVM currently
+            // The bytecodeHash is hardcoded here because type(ERC1967Proxy).creationCode doesn't work on eraVM currently
             // If you failed some test cases, check the bytecodeHash by yourself
             // see, test/ComputeCreate2Address.t.sol
             return


### PR DESCRIPTION
This problem has been fixed because we fixed solc and zksolc versions in foundry.toml.
Maybe the section in README.md has been left as is, as the bytecode hash change is necessary if developers want to use different solc and zksolc versions.