### PR TITLE
Add Re: to subject in email replies

### DIFF
--- a/packages/relayer/src/modules/mail.rs
+++ b/packages/relayer/src/modules/mail.rs
@@ -332,7 +332,7 @@ pub async fn handle_email_event(event: EmailAuthEvent) -> Result<()> {
             );
             let render_data = serde_json::json!({"userEmailAddr": email_addr, "request": subject});
             let body_html = render_html("acknowledgement.html", render_data).await?;
-            let subject = format!("Email Wallet Notification. Acknowledgement.");
+            let subject = format!("Re: {}", subject);
             let email = EmailMessage {
                 to: email_addr,
                 subject,


### PR DESCRIPTION
Use the original subject of emails and add "Re: " at the beginning, so email programs pick it up in threads.