### PR TITLE
Feat/fix zksync commands

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -228,6 +228,9 @@ yarn build
 
 # Install foundry-zksync, please follow this URL
 https://foundry-book.zksync.io/getting-started/installation
+
+# Install era-test-node
+https://github.com/matter-labs/era-test-node
 ```
 
 Next, you should uncomment the following lines in `foundry.toml`.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -216,8 +216,9 @@ It also provides the following entry functions with their default implementation
     5. Assert that `EmailAuth(guardian).authEmail(emailAuthMsg)` returns no error.
     6. Call `processRecovery(guardian, templateIdx, emailAuthMsg.commandParams, emailAuthMsg.proof.emailNullifier)`.
 
-# For zkSync
+# For ZKsync
 
+## Set up and build
 ```
 # Install foundry
 foundryup
@@ -225,8 +226,7 @@ foundryup
 cd packages/contracts
 yarn build
 
-# Install foundry-zksync
-Please follow this URL
+# Install foundry-zksync, please follow this URL
 https://foundry-book.zksync.io/getting-started/installation
 ```
 
@@ -242,12 +242,11 @@ Partial comment-out files can be found the following. Please uncomment them.
 - src/utils/ZKSyncCreate2Factory.sol
 - test/helpers/DeploymentHelper.sol
 
-In contrast, at this point you need to comment out the following files. We plan to fix this issue in the near future:
+Run the era-test-node forking zksync sepolia
 
-- test/libraries/StringUtils/hexToBytes.t.sol
-- test/libraries/StringUtils/hexToBytes32.t.sol
-- test/libraries/StringUtils/fuzz/hexToBytes.t.sol
-- test/libraries/StringUtils/fuzz/hexToBytes32.t.sol
+```
+era_test_node fork https://sepolia.era.zksync.dev
+```
 
 At the first forge build, you need to detect the missing libraries.
 
@@ -260,193 +259,115 @@ You can deploy them by the following command for example.
 
 ```
 $ forge build --zksync --zk-detect-missing-libraries
-Missing libraries detected: src/libraries/CommandUtils.sol:CommandUtils, src/libraries/DecimalUtils.sol:DecimalUtils
+Missing libraries detected: src/libraries/CommandUtils.sol:CommandUtils, src/libraries/DecimalUtils.sol:DecimalUtils, src/libraries/StringUtils.sol:StringUtils
 ```
 
-Run the following command in order to deploy each missing library:
-
-The following commands are for deploying to zksync sepolia. If you want to deploy to other networks like zksync mainnet, please change the RPC_URL and CHAIN_ID accordingly.
+Run the following command in order to deploy each missing libraries:
 
 ```
 export PRIVATE_KEY={YOUR_PRIVATE_KEY}
-export RPC_URL=https://sepolia.era.zksync.dev
-export CHAIN_ID=300
+export RPC_URL=http://127.0.0.1:8011
+export CHAIN_ID=260
+
 forge create src/libraries/DecimalUtils.sol:DecimalUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync
 forge create src/libraries/CommandUtils.sol:CommandUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync --libraries src/libraries/DecimalUtils.sol:DecimalUtils:{DECIMAL_UTILS_ADDRESS_YOU_DEPLOYED}
+forge create src/libraries/StringUtils.sol:StringUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync
 ```
 
-After that, you can see the following line in foundry.toml.
-Also, this line is needed only for foundry-zksync, if you use foundry, please remove this line. Otherwise, the test will fail.
+After that, you can see the following lines in the foundry.toml. Please replace `{PROJECT_DIR}` and `{DEPLOYED_ADDRESS}`.
+Also, this lines are needed only for foundry-zksync, if you use normal foundry commands, please comment out. 
+
 
 ```
 libraries = [
     "{PROJECT_DIR}/packages/contracts/src/libraries/DecimalUtils.sol:DecimalUtils:{DEPLOYED_ADDRESS}", 
     "{PROJECT_DIR}/packages/contracts/src/libraries/CommandUtils.sol:CommandUtils:{DEPLOYED_ADDRESS}"
-    "{PROJECT_DIR}/packages/contracts/src/libraries/StringUtils.sol:StringUtils:{DEPLOYED_ADDRESS}" # IF YOU WANT
+    "{PROJECT_DIR}/packages/contracts/src/libraries/StringUtils.sol:StringUtils:{DEPLOYED_ADDRESS}"
 ]
 ```
 
-Incidentally, the above line already exists in `foundy.toml` with it commented out, if you uncomment it by replacing `{PROJECT_DIR}` with the appropriate path, it will also work.
-
 About Create2, `L2ContractHelper.computeCreate2Address` should be used.
-And `type(ERC1967Proxy).creationCode` doesn't work correctly in zkSync.
-We need to hardcode the `type(ERC1967Proxy).creationCode` to bytecodeHash.
-Perhaps that is a different value in each compiler version.
+`type(ERC1967Proxy).creationCode` doesn't work correctly in ZKsync.
+We need to use the bytecode hash intead of `type(ERC1967Proxy).creationCode`.
+Perhaps that is a different value in each compiler version and library addresses.
 
-Run this command, you'll get the bytecode hash.
+Run the following commands, you'll get the bytecode hash.
 
 ```
-forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv
+forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv --fork-url http://127.0.0.1:8011
 ```
 
-And then, you should set the PROXY_BYTECODE_HASH in the .env
+And then, you should replace `{YOUR_BYTECODE_HASH}` in the .env
 
 ```
 PROXY_BYTECODE_HASH={YOUR_BYTECODE_HASH}
 ```
 
-# For zkSync testing
+## Unit tests
 
-Run the following command
+Run the following commands
 
 ```
 source .env
 yarn zktest
 ```
 
-Current foundry-zksync overrides the foundry behavior. If you installed foundry-zksync, some EVM code will be different and some test cases will fail. If you want to test on other EVM, please install foundry.
+Even if the contract size is fine for EVM, it may exceed the bytecode size limit for zksync, and the test may not be executed. If you encountered the contract size error, please consider the contract design.
 
-Even if the contract size is fine for EVM, it may exceed the bytecode size limit for zksync, and the test may not be executed.
-Therefore, EmailAccountRecovery.t.sol has been split.
-
-Currently, some test cases are not working correctly because there is an issue about missing libraries.
-
-https://github.com/matter-labs/foundry-zksync/issues/382
-
-Failing test cases are here.
-
-DKIMRegistryUpgrade.t.sol
-
-- testAuthEmail()
-
-EmailAuth.t.sol
-
-- testAuthEmail()
-- testExpectRevertAuthEmailEmailNullifierAlreadyUsed() 
-- testExpectRevertAuthEmailInvalidEmailProof()
-- testExpectRevertAuthEmailInvalidCommand()
-- testExpectRevertAuthEmailInvalidTimestamp()
-
-EmailAuthWithUserOverrideableDkim.t.sol
-
-- testAuthEmailAfterEnabled()
-- testAuthEmailBeforeEnabled()
-
-# For integration testing
-
-To pass the integration testing, you should use era-test-node. 
-See the following URL and install it.
-https://github.com/matter-labs/era-test-node
-
-Run the era-test-node forking zksync sepolia
-
-```
-era_test_node fork https://sepolia.era.zksync.dev
-```
-
-You remove .zksolc-libraries-cache directory, and run the following command.
-
-```
-forge build --zksync --zk-detect-missing-libraries
-```
-
-As you saw before, you need to deploy missing libraries.
-You can deploy them by the following command for example.
-
-Run the following command in order to deploy each missing library:
-
-```
-export PRIVATE_KEY={YOUR_PRIVATE_KEY}
-export RPC_URL=http://127.0.0.1:8011
-export CHAIN_ID=260
-forge create src/libraries/DecimalUtils.sol:DecimalUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync
-forge create src/libraries/CommandUtils.sol:CommandUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync --libraries src/libraries/DecimalUtils.sol:DecimalUtils:{DECIMAL_UTILS_ADDRESS_YOU_DEPLOYED} --gas-limit 1000000000
-```
-
-Set the libraries in foundry.toml using the above deployed address.
-
-Run this command, you'll get the bytecode hash.
-
-```
-forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv
-```
-
-And then, you should set the PROXY_BYTECODE_HASH in the .env
-
-```
-PROXY_BYTECODE_HASH={YOUR_BYTECODE_HASH}
-```
-
-And then, run the integration testing.
+## Integration tests
 
 ```
 source .env
 forge test --match-contract "IntegrationZKSyncTest" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv --ffi
 ```
 
-# For zkSync deployment (For test net)
+## Deployment (For zksync sepolia)
 
 As you saw before, you need to deploy missing libraries.
-You can deploy them by the following command for example.
+You can deploy them by the following commands for example.
 
 ```
 export PRIVATE_KEY={YOUR_PRIVATE_KEY}
 export RPC_URL=https://sepolia.era.zksync.dev
 export CHAIN_ID=300
+
 forge create src/libraries/DecimalUtils.sol:DecimalUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync
 forge create src/libraries/CommandUtils.sol:CommandUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync --libraries src/libraries/DecimalUtils.sol:DecimalUtils:{DECIMAL_UTILS_ADDRESS_YOU_DEPLOYED}
-```
-
-We have StringUtils in this repo, but this repo don't use this util contract. 
-If you want to use this, you need to deploy.
-
-```
 forge create src/libraries/StringUtils.sol:StringUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync
 ```
 
-After that, you can see the following line in foundry.toml.
-Also, this line is needed only for foundry-zksync, if you use foundry, please remove this line. Otherwise, the test will fail.
+And then you need to replace `{PROJECT_DIR}` and `{DEPLOYED_ADDRESS}` in the foundy.toml.
 
 ```
 libraries = [
     "{PROJECT_DIR}/packages/contracts/src/libraries/DecimalUtils.sol:DecimalUtils:{DEPLOYED_ADDRESS}", 
     "{PROJECT_DIR}/packages/contracts/src/libraries/CommandUtils.sol:CommandUtils:{DEPLOYED_ADDRESS}"]
-    "{PROJECT_DIR}/packages/contracts/src/libraries/StringUtils.sol:StringUtils:{DEPLOYED_ADDRESS}" # IF YOU WANT    
+    "{PROJECT_DIR}/packages/contracts/src/libraries/StringUtils.sol:StringUtils:{DEPLOYED_ADDRESS}"
 ```
 
-Incidentally, the above line already exists in `foundy.toml` with it commented out, if you uncomment it by replacing `{PROJECT_DIR}` with the appropriate path, it will also work.
-
-Run this command, you'll get the bytecode hash.
+Run this command again, you'll get the bytecode hash.
 
 ```
-forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv
+forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv --fork-url http://127.0.0.1:8011
 ```
 
-And then, you should set the PROXY_BYTECODE_HASH in the .env
+And then, you should replace `{YOUR_BYTECODE_HASH}` in the .env
 
 ```
 PROXY_BYTECODE_HASH={YOUR_BYTECODE_HASH}
 ```
 
-You need to edit .env at first.
-Second just run the following commands with `--zksync`
+Run the deploy script
 
 ```
 source .env
+
+export RPC_URL=https://sepolia.era.zksync.dev
+export CHAIN_ID=300
+
 forge script script/DeployRecoveryControllerZKSync.s.sol:Deploy --zksync --rpc-url $RPC_URL --broadcast --slow --via-ir --system-mode true -vvvv 
 ```
 
-
-## Emergency Response
+# Emergency Response
 
 For information on how upgrade contracts for handling emergency situations, please refer to our [Upgrading Contracts](../../docs/upgrade.md).

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -23,10 +23,11 @@ ast = true
 build_info = true
 extra_output = ["storageLayout"]
 
-# For missing libraries, please comment out this if you use foundry-zksync for unit test
+# For missing libraries, please comment out following line and replace some placeholders if you use foundry-zksync
 #libraries = [
-#    "{PROJECT_DIR}/packages/contracts/src/libraries/DecimalUtils.sol:DecimalUtils:{DEPLOYED_ADDRESS}", 
-#    "{PROJECT_DIR}/packages/contracts/src/libraries/CommandUtils.sol:CommandUtils:{DEPLOYED_ADDRESS}"
+#    "{PROJECT_DIR}/packages/contracts/src/libraries/DecimalUtils.sol:DecimalUtils:{DEPLOYED_ADDRESS}",
+#    "{PROJECT_DIR}/packages/contracts/src/libraries/CommandUtils.sol:CommandUtils:{DEPLOYED_ADDRESS}",
+#    "{PROJECT_DIR}/packages/contracts/src/libraries/StringUtils.sol:StringUtils:{DEPLOYED_ADDRESS}"
 #]
 
 [rpc_endpoints]

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -6,8 +6,8 @@
     "build": "forge build --skip '*ZKSync*'",
     "test": "forge test --force --no-match-test \"testIntegration\" --no-match-contract \".*Script.*\" --skip '*ZKSync*'",
     "test:script": "forge test --force --no-match-test \"testIntegration\" --skip '*ZKSync*' --match-path test/script/**/*.sol --threads 1",
-    "zkbuild": "forge build --zksync",
-    "zktest": "forge test --no-match-test \"testIntegration\" --no-match-contract \".*Script.*|StringUtils_HexToBytes*\" --system-mode=true --zksync --gas-limit 2000000000 --chain 300",
+    "zkbuild": "forge build --skip test --zksync",
+    "zktest": "forge test --no-match-test \"testIntegration\" --no-match-contract \".*Script.*\" --system-mode=true --zksync --gas-limit 2000000000 --chain 300 --fork-url http://127.0.0.1:8011",
     "lint": "solhint 'src/**/*.sol'"
   },
   "dependencies": {

--- a/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_completeRecovery.t.sol
+++ b/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_completeRecovery.t.sol
@@ -163,7 +163,7 @@ contract EmailAccountRecoveryZKSyncTest_completeRecovery is StructHelper {
         );
 
         vm.startPrank(someRelayer);
-        vm.warp(4 days);
+        vm.warp(block.timestamp + 4 days);
         recoveryControllerZKSync.completeRecovery(
             address(simpleWallet),
             new bytes(0)
@@ -213,7 +213,7 @@ contract EmailAccountRecoveryZKSyncTest_completeRecovery is StructHelper {
         );
 
         vm.startPrank(someRelayer);
-        vm.warp(4 days);
+        vm.warp(block.timestamp + 4 days);
         vm.expectRevert(bytes("recovery not in progress"));
         bytes memory recoveryCalldata;
         recoveryControllerZKSync.completeRecovery(

--- a/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_transfer.t.sol
+++ b/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_transfer.t.sol
@@ -21,9 +21,11 @@ contract EmailAccountRecoveryZKSyncTest_transfer is StructHelper {
 
         setUp();
 
+        vm.deal(address(simpleWallet), 1 ether);
         assertEq(address(simpleWallet).balance, 1 ether);
-        assertEq(receiver.balance, 0 ether);
 
+        vm.deal(receiver, 0 ether);
+        assertEq(receiver.balance, 0 ether);
         vm.startPrank(deployer);
         simpleWallet.transfer(receiver, 1 ether);
         vm.stopPrank();
@@ -37,7 +39,10 @@ contract EmailAccountRecoveryZKSyncTest_transfer is StructHelper {
 
         setUp();
 
+        vm.deal(address(simpleWallet), 1 ether);
         assertEq(address(simpleWallet).balance, 1 ether);
+
+        vm.deal(receiver, 0 ether);
         assertEq(receiver.balance, 0 ether);
 
         vm.startPrank(receiver);
@@ -55,12 +60,13 @@ contract EmailAccountRecoveryZKSyncTest_transfer is StructHelper {
         skipIfNotZkSync();
 
         setUp();
-
+        vm.deal(address(simpleWallet), 1 ether);
         assertEq(address(simpleWallet).balance, 1 ether);
+
+        vm.deal(receiver, 0 ether);
         assertEq(receiver.balance, 0 ether);
 
         vm.startPrank(deployer);
-        assertEq(receiver.balance, 0 ether);
         vm.expectRevert(bytes("insufficient balance"));
         simpleWallet.transfer(receiver, 2 ether);
         vm.stopPrank();

--- a/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_withdraw.t.sol
+++ b/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_withdraw.t.sol
@@ -21,8 +21,10 @@ contract EmailAccountRecoveryZKSyncTest_withdraw is StructHelper {
 
         setUp();
 
+        vm.deal(address(simpleWallet), 1 ether);
         assertEq(address(simpleWallet).balance, 1 ether);
-        assertEq(deployer.balance, 0 ether);
+
+        vm.deal(deployer, 0 ether);
 
         vm.startPrank(deployer);
         simpleWallet.withdraw(1 ether);
@@ -38,7 +40,6 @@ contract EmailAccountRecoveryZKSyncTest_withdraw is StructHelper {
         setUp();
 
         assertEq(address(simpleWallet).balance, 1 ether);
-        assertEq(deployer.balance, 0 ether);
 
         vm.startPrank(receiver);
         vm.expectRevert(
@@ -57,7 +58,6 @@ contract EmailAccountRecoveryZKSyncTest_withdraw is StructHelper {
         setUp();
 
         assertEq(address(simpleWallet).balance, 1 ether);
-        assertEq(deployer.balance, 0 ether);
 
         vm.startPrank(deployer);
         vm.expectRevert(bytes("insufficient balance"));

--- a/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes.t.sol
+++ b/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes.t.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { StringUtils } from "src/libraries/StringUtils.sol";
+import {StringUtils} from "src/libraries/StringUtils.sol";
 import {StructHelper} from "../../helpers/StructHelper.sol";
 
 contract StringUtils_HexToBytes_Test is StructHelper {
@@ -11,8 +10,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
     }
 
     function test_HexToBytes_RevertWhen_InvalidHexPrefix() public {
-        string memory bytesStringNoHexPrefix =
-            "509d286573e85f37b51f178c1";
+        string memory bytesStringNoHexPrefix = "509d286573e85f37b51f178c1";
 
         vm.expectRevert("invalid hex prefix");
         StringUtils.hexToBytes(bytesStringNoHexPrefix);
@@ -33,38 +31,46 @@ contract StringUtils_HexToBytes_Test is StructHelper {
     }
 
     function test_HexToBytes_RevertWhen_IncorrectPrefix_CapitalLetter() public {
-        string memory invalidPrefixBytesString =
-            "0X509d376452ba746b093a149f9d733c145539771d";
+        string
+            memory invalidPrefixBytesString = "0X509d376452ba746b093a149f9d733c145539771d";
 
         vm.expectRevert("invalid hex prefix");
         StringUtils.hexToBytes(invalidPrefixBytesString);
     }
 
-    function test_HexToBytes_RevertWhen_InvalidHexPrefix_LeadingWhitespace() public {
-        string memory bytesString =
-            " 0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145746b093a149f9d733c1539771d";
+    function test_HexToBytes_RevertWhen_InvalidHexPrefix_LeadingWhitespace()
+        public
+    {
+        string
+            memory bytesString = " 0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145746b093a149f9d733c1539771d";
 
         vm.expectRevert("invalid hex prefix");
         StringUtils.hexToBytes(bytesString);
     }
 
-    function test_HexToBytes_RevertWhen_InvalidHexStringLength_TrailingWhitespace() public {
-        string memory bytesString =
-            "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c1455d286573e85f37b51f178c1cf8376452ba746b093Ca149f9d733c145539771d ";
+    function test_HexToBytes_RevertWhen_InvalidHexStringLength_TrailingWhitespace()
+        public
+    {
+        string
+            memory bytesString = "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c1455d286573e85f37b51f178c1cf8376452ba746b093Ca149f9d733c145539771d ";
 
         vm.expectRevert("invalid hex string length");
         StringUtils.hexToBytes(bytesString);
     }
 
-    function test_HexToBytes_RevertWhen_InvalidHexStringLength_ZeroShortBytes() public {
+    function test_HexToBytes_RevertWhen_InvalidHexStringLength_ZeroShortBytes()
+        public
+    {
         string memory shortBytesString = "0x";
         vm.expectRevert("invalid hex string length");
         StringUtils.hexToBytes(shortBytesString);
     }
 
-    function test_HexToBytes_RevertWhen_InvalidHexStringLength_TooHigh() public {
-        string memory invalidBytesString =
-            "0x509D286573e85F37b51F178c1cf8376452ba746b093A149f9d733c145539771dd"; // extra character
+    function test_HexToBytes_RevertWhen_InvalidHexStringLength_TooHigh()
+        public
+    {
+        string
+            memory invalidBytesString = "0x509D286573e85F37b51F178c1cf8376452ba746b093A149f9d733c145539771dd"; // extra character
 
         vm.expectRevert("invalid hex string length");
         StringUtils.hexToBytes(invalidBytesString);
@@ -72,24 +78,26 @@ contract StringUtils_HexToBytes_Test is StructHelper {
 
     function test_HexToBytes_RevertWhen_InvalidHexStringLength_TooLow() public {
         // hardcoded bytes memory value with final character removed
-        string memory shortBytesString =
-            "0xdbc39d6cd28b2a38b8af5d4892c194bea383af28e55e7430d26474150280f15";
+        string
+            memory shortBytesString = "0xdbc39d6cd28b2a38b8af5d4892c194bea383af28e55e7430d26474150280f15";
 
         vm.expectRevert("invalid hex string length");
         StringUtils.hexToBytes(shortBytesString);
     }
 
-    function test_HexToBytes_RevertWhen_InvalidHexChar_SingleNonHexChar() public {
-        string memory invalidContentBytesString =
-            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeG"; // G
+    function test_HexToBytes_RevertWhen_InvalidHexChar_SingleNonHexChar()
+        public
+    {
+        string
+            memory invalidContentBytesString = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeG"; // G
 
         vm.expectRevert("invalid hex char");
         StringUtils.hexToBytes(invalidContentBytesString);
     }
 
     function test_HexToBytes_RevertWhen_InvalidHexChar() public {
-        string memory invalidBytesString =
-            "0x509d2865zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+        string
+            memory invalidBytesString = "0x509d2865zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
 
         vm.expectRevert("invalid hex char");
         StringUtils.hexToBytes(invalidBytesString);
@@ -99,8 +107,8 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         bytes memory expectedBytes = abi.encodePacked(
             hex"509d286573e85f37b51f178c1cf8376452509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837ba746b093a149f9d733c145539771d509d286573e85509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837f37b509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf83751f178c1cf837509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf83764"
         );
-        string memory longBytesString =
-            "0x509d286573e85f37b51f178c1cf8376452509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837ba746b093a149f9d733c145539771d509d286573e85509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837f37b509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf83751f178c1cf837509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf83764";
+        string
+            memory longBytesString = "0x509d286573e85f37b51f178c1cf8376452509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837ba746b093a149f9d733c145539771d509d286573e85509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf837f37b509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf83751f178c1cf837509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf83764";
 
         bytes memory bytesResult = StringUtils.hexToBytes(longBytesString);
 
@@ -109,22 +117,23 @@ contract StringUtils_HexToBytes_Test is StructHelper {
 
     function test_HexToBytes_SucceesWhen_SingleCapitalLetter() public {
         // hardcoded bytes memory value with final character capitalized
-        bytes memory expectedBytes =
-            abi.encodePacked(hex"509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771D");
-        string memory bytesString =
-            "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771D";
+        bytes memory expectedBytes = abi.encodePacked(
+            hex"509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771D"
+        );
+        string
+            memory bytesString = "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771D";
 
         bytes memory result = StringUtils.hexToBytes(bytesString);
 
         assertEq(result, expectedBytes);
     }
 
-
     function test_HexToBytes_SucceedsWhen_MixedCaseHex() public {
-        bytes memory expectedMixedCaseBytes =
-            abi.encodePacked(hex"509D286573e85F37b51F178c1cf8376452ba746b093A149f9d733c145539771d");
-        string memory mixedCaseString =
-            "0x509D286573e85F37b51F178c1cf8376452ba746b093A149f9d733c145539771d";
+        bytes memory expectedMixedCaseBytes = abi.encodePacked(
+            hex"509D286573e85F37b51F178c1cf8376452ba746b093A149f9d733c145539771d"
+        );
+        string
+            memory mixedCaseString = "0x509D286573e85F37b51F178c1cf8376452ba746b093A149f9d733c145539771d";
 
         bytes memory result = StringUtils.hexToBytes(mixedCaseString);
 
@@ -132,10 +141,11 @@ contract StringUtils_HexToBytes_Test is StructHelper {
     }
 
     function test_HexToBytes_ConvertsZeroBytes() public pure {
-        bytes memory zeroBytes =
-            abi.encodePacked(hex"0000000000000000000000000000000000000000000000000000000000000000");
-        string memory invalidBytesString =
-            "0x0000000000000000000000000000000000000000000000000000000000000000";
+        bytes memory zeroBytes = abi.encodePacked(
+            hex"0000000000000000000000000000000000000000000000000000000000000000"
+        );
+        string
+            memory invalidBytesString = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
         bytes memory result = StringUtils.hexToBytes(invalidBytesString);
 
@@ -143,18 +153,18 @@ contract StringUtils_HexToBytes_Test is StructHelper {
     }
 
     function test_hexToBytes_ComputesExpectedBytes() public pure {
-        bytes memory expectedBytes1 =
-            abi.encodePacked(hex"509d");
-        bytes memory expectedBytes2 =
-            abi.encodePacked(hex"a2baeb0f5a80b8f086147ffc05236f2d243357d9240c080a821b2aa987cb150c");
-        bytes memory expectedBytes3 =
-            abi.encodePacked(hex"ac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9ac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9");
-        string memory bytesString1 =
-            "0x509d";
-        string memory bytesString2 =
-            "0xa2baeb0f5a80b8f086147ffc05236f2d243357d9240c080a821b2aa987cb150c";
-        string memory bytesString3 =
-            "0xac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9ac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9";
+        bytes memory expectedBytes1 = abi.encodePacked(hex"509d");
+        bytes memory expectedBytes2 = abi.encodePacked(
+            hex"a2baeb0f5a80b8f086147ffc05236f2d243357d9240c080a821b2aa987cb150c"
+        );
+        bytes memory expectedBytes3 = abi.encodePacked(
+            hex"ac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9ac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9"
+        );
+        string memory bytesString1 = "0x509d";
+        string
+            memory bytesString2 = "0xa2baeb0f5a80b8f086147ffc05236f2d243357d9240c080a821b2aa987cb150c";
+        string
+            memory bytesString3 = "0xac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9ac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9";
 
         bytes memory bytesResult1 = StringUtils.hexToBytes(bytesString1);
         bytes memory bytesResult2 = StringUtils.hexToBytes(bytesString2);
@@ -172,9 +182,12 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         bytes memory expectedBytes1 = abi.encodePacked(addressToBytes1);
         bytes memory expectedBytes2 = abi.encodePacked(addressToBytes2);
         bytes memory expectedBytes3 = abi.encodePacked(addressToBytes3);
-        string memory bytesString1 = "0x0000000000000000000000000000000000000001";
-        string memory bytesString2 = "0xf9c73eedad50dc6de889450c6469f4ba78a826dd";
-        string memory bytesString3 = "0x328809bc894f92807417d2dad6b7c998c1afdac6";
+        string
+            memory bytesString1 = "0x0000000000000000000000000000000000000001";
+        string
+            memory bytesString2 = "0xf9c73eedad50dc6de889450c6469f4ba78a826dd";
+        string
+            memory bytesString3 = "0x328809bc894f92807417d2dad6b7c998c1afdac6";
 
         bytes memory bytesResult1 = StringUtils.hexToBytes(bytesString1);
         bytes memory bytesResult2 = StringUtils.hexToBytes(bytesString2);
@@ -192,19 +205,25 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         address validator = 0x756e0562323ADcDA4430d6cb456d9151f605290B;
 
         bytes memory calldata1 = abi.encodeWithSignature(
-            "swapOwner(address,address,address)", address(1), owner, newOwner
+            "swapOwner(address,address,address)",
+            address(1),
+            owner,
+            newOwner
         );
         bytes memory recoveryData1 = abi.encode(account, calldata1);
         bytes memory recoveryDataBytes1 = recoveryData1;
 
-        bytes memory calldata2 = abi.encodeWithSignature("changeOwner(address)", newOwner);
+        bytes memory calldata2 = abi.encodeWithSignature(
+            "changeOwner(address)",
+            newOwner
+        );
         bytes memory recoveryData2 = abi.encode(validator, calldata2);
         bytes memory recoveryDataBytes2 = recoveryData2;
 
-        string memory bytesString1 =
-            "0x000000000000000000000000f4f7b3d8e43a41833774cd6d962d10282f80601700000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000064e318b52b0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000ce9a87013db006dde79e7382bf48d45bf891e90d00000000000000000000000063aaf092604406c03e5b36ca1bec1cddf4a5fa9d00000000000000000000000000000000000000000000000000000000";
-        string memory bytesString2 =
-            "0x000000000000000000000000756e0562323adcda4430d6cb456d9151f605290b00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000024a6f9dae100000000000000000000000063aaf092604406c03e5b36ca1bec1cddf4a5fa9d00000000000000000000000000000000000000000000000000000000";
+        string
+            memory bytesString1 = "0x000000000000000000000000f4f7b3d8e43a41833774cd6d962d10282f80601700000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000064e318b52b0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000ce9a87013db006dde79e7382bf48d45bf891e90d00000000000000000000000063aaf092604406c03e5b36ca1bec1cddf4a5fa9d00000000000000000000000000000000000000000000000000000000";
+        string
+            memory bytesString2 = "0x000000000000000000000000756e0562323adcda4430d6cb456d9151f605290b00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000024a6f9dae100000000000000000000000063aaf092604406c03e5b36ca1bec1cddf4a5fa9d00000000000000000000000000000000000000000000000000000000";
 
         bytes memory bytesResult1 = StringUtils.hexToBytes(bytesString1);
         bytes memory bytesResult2 = StringUtils.hexToBytes(bytesString2);
@@ -214,10 +233,11 @@ contract StringUtils_HexToBytes_Test is StructHelper {
     }
 
     function test_HexToBytes_MaximumValue() public pure {
-        bytes memory maxBytes32 =
-            bytes(hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        string memory maxBytesString =
-            "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        bytes memory maxBytes32 = bytes(
+            hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        );
+        string
+            memory maxBytesString = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
         bytes memory result = StringUtils.hexToBytes(maxBytesString);
 

--- a/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes32.t.sol
+++ b/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes32.t.sol
@@ -1,26 +1,25 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { StringUtils } from "src/libraries/StringUtils.sol";
-import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import {StringUtils} from "src/libraries/StringUtils.sol";
 import {StructHelper} from "../../helpers/StructHelper.sol";
 
 contract StringUtils_HexToBytes32_Test is StructHelper {
-    using Strings for uint256;
-    
     function setUp() public override {
         super.setUp();
     }
 
     function test_HexToBytes32_RevertWhen_InvalidHexPrefix() public {
-        string memory invalidPrefixHashString =
-            "509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d";
+        string
+            memory invalidPrefixHashString = "509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d";
 
         vm.expectRevert("invalid hex prefix");
         StringUtils.hexToBytes32(invalidPrefixHashString);
     }
 
-    function test_HexToBytes32_RevertWhen_InvalidHexPrefix_EmptyString() public {
+    function test_HexToBytes32_RevertWhen_InvalidHexPrefix_EmptyString()
+        public
+    {
         string memory emptyString = "";
 
         vm.expectRevert("invalid hex prefix");
@@ -34,91 +33,109 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(shortHashString);
     }
 
-    function test_HexToBytes32_RevertWhen_IncorrectPrefix_CapitalLetter() public {
-        string memory invalidPrefixHashString =
-            "0X509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d";
+    function test_HexToBytes32_RevertWhen_IncorrectPrefix_CapitalLetter()
+        public
+    {
+        string
+            memory invalidPrefixHashString = "0X509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d";
 
         vm.expectRevert("invalid hex prefix");
         StringUtils.hexToBytes32(invalidPrefixHashString);
     }
 
-    function test_HexToBytes32_RevertWhen_InvalidHexPrefix_LeadingWhitespace() public {
-        string memory hashString =
-            " 0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d";
+    function test_HexToBytes32_RevertWhen_InvalidHexPrefix_LeadingWhitespace()
+        public
+    {
+        string
+            memory hashString = " 0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d";
 
         vm.expectRevert("invalid hex prefix");
         StringUtils.hexToBytes32(hashString);
     }
 
-    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TrailingWhitespace() public {
-        string memory hashString =
-            "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d ";
+    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TrailingWhitespace()
+        public
+    {
+        string
+            memory hashString = "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d ";
 
         vm.expectRevert("invalid hex string length");
         StringUtils.hexToBytes32(hashString);
     }
 
-    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_ZeroBytes() public {
+    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_ZeroBytes()
+        public
+    {
         string memory shortHashString = "0x";
 
         vm.expectRevert("invalid hex string length");
         StringUtils.hexToBytes32(shortHashString);
     }
 
-    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_ZeroShortBytes() public {
+    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_ZeroShortBytes()
+        public
+    {
         string memory shortHashString = "0x00";
 
         vm.expectRevert("bytes length is not 32");
         StringUtils.hexToBytes32(shortHashString);
     }
 
-    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TooHigh() public {
+    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TooHigh()
+        public
+    {
         string memory stringToHash = "I'm a test string";
         bytes32 expectedHash = keccak256(abi.encodePacked(stringToHash));
-        string memory invalidHashString = uint256(expectedHash).toHexString(33);
+        string
+            memory invalidHashString = "0x00dbc39d6cd28b2a38b8af5d4892c194bea383af28e55e7430d26474150280f15e";
 
         vm.expectRevert("bytes length is not 32");
         StringUtils.hexToBytes32(invalidHashString);
     }
 
-    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_VeryLongInput() public {
-        string memory longHashString =
-            "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf83764";
+    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_VeryLongInput()
+        public
+    {
+        string
+            memory longHashString = "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d509d286573e85f37b51f178c1cf83764";
 
         vm.expectRevert("bytes length is not 32");
         StringUtils.hexToBytes32(longHashString);
     }
 
-    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TooLow() public {
+    function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TooLow()
+        public
+    {
         // hardcoded bytes32 value with final character removed
-        string memory shortHashString =
-            "0xdbc39d6cd28b2a38b8af5d4892c194bea383af28e55e7430d26474150280f15";
+        string
+            memory shortHashString = "0xdbc39d6cd28b2a38b8af5d4892c194bea383af28e55e7430d26474150280f15";
 
         vm.expectRevert("invalid hex string length");
         StringUtils.hexToBytes32(shortHashString);
     }
 
-    function test_HexToBytes32_RevertWhen_InvalidHexChar_SingleNonHexChar() public {
-        string memory invalidContentHashString =
-            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeG"; // G
+    function test_HexToBytes32_RevertWhen_InvalidHexChar_SingleNonHexChar()
+        public
+    {
+        string
+            memory invalidContentHashString = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeG"; // G
 
         vm.expectRevert("invalid hex char");
         StringUtils.hexToBytes32(invalidContentHashString);
     }
 
     function test_HexToBytes32_RevertWhen_InvalidHexChar() public {
-        string memory invalidHashString =
-            "0x509d2865zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+        string
+            memory invalidHashString = "0x509d2865zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
 
         vm.expectRevert("invalid hex char");
         StringUtils.hexToBytes32(invalidHashString);
     }
 
     function test_HexToBytes32_SucceedsWhen_MixedCaseHex() public {
-        bytes32 expectedMixedCaseHash =
-            0x509D286573e85F37b51F178c1cf8376452ba746b093A149f9d733c145539771d;
-        string memory mixedCaseHashString =
-            "0x509D286573e85F37b51F178c1cf8376452ba746b093A149f9d733c145539771d";
+        bytes32 expectedMixedCaseHash = 0x509D286573e85F37b51F178c1cf8376452ba746b093A149f9d733c145539771d;
+        string
+            memory mixedCaseHashString = "0x509D286573e85F37b51F178c1cf8376452ba746b093A149f9d733c145539771d";
 
         bytes32 result = StringUtils.hexToBytes32(mixedCaseHashString);
 
@@ -128,8 +145,8 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
     function test_HexToBytes32_SucceedsWhen_SingleCapitalLetter() public {
         // hardcoded bytes32 value with final character capitalized
         bytes32 expectedHash = 0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771D;
-        string memory hashString =
-            "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771D";
+        string
+            memory hashString = "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771D";
 
         bytes32 result = StringUtils.hexToBytes32(hashString);
 
@@ -138,10 +155,9 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
 
     function test_HexToBytes32_ConvertsZeroHash() public pure {
         bytes32 zeroHash = bytes32(0);
-        string memory invalidHashString = uint256(0).toHexString(32);
-
+        string
+            memory invalidHashString = "0x0000000000000000000000000000000000000000000000000000000000000000";
         bytes32 result = StringUtils.hexToBytes32(invalidHashString);
-
         assertEq(result, zeroHash);
     }
 
@@ -149,12 +165,12 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         bytes32 expectedHash1 = 0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d;
         bytes32 expectedHash2 = 0xa2baeb0f5a80b8f086147ffc05236f2d243357d9240c080a821b2aa987cb150c;
         bytes32 expectedHash3 = 0xac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9;
-        string memory hashString1 =
-            "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d";
-        string memory hashString2 =
-            "0xa2baeb0f5a80b8f086147ffc05236f2d243357d9240c080a821b2aa987cb150c";
-        string memory hashString3 =
-            "0xac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9";
+        string
+            memory hashString1 = "0x509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d";
+        string
+            memory hashString2 = "0xa2baeb0f5a80b8f086147ffc05236f2d243357d9240c080a821b2aa987cb150c";
+        string
+            memory hashString3 = "0xac276f708bfba694fe2f7bfdc52e6b158a612c72f88a72bddacdfb33f190e9b9";
 
         bytes32 hashResult1 = StringUtils.hexToBytes32(hashString1);
         bytes32 hashResult2 = StringUtils.hexToBytes32(hashString2);
@@ -172,12 +188,12 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         bytes32 expectedHash1 = keccak256(abi.encodePacked(addressToHash1));
         bytes32 expectedHash2 = keccak256(abi.encodePacked(addressToHash2));
         bytes32 expectedHash3 = keccak256(abi.encodePacked(addressToHash3));
-        string memory hashString1 =
-            "0x1468288056310c82aa4c01a7e12a10f8111a0560e72b700555479031b86c357d";
-        string memory hashString2 =
-            "0x74f5064398929fa4a58c46b60031ae3e0788e7e2e9294b06e0a82978f22ad502";
-        string memory hashString3 =
-            "0x72d7a3f1e9fa3953b9dfa6828dd4d4068abbe2041e121a61f102e1f7f9603d2a";
+        string
+            memory hashString1 = "0x1468288056310c82aa4c01a7e12a10f8111a0560e72b700555479031b86c357d";
+        string
+            memory hashString2 = "0x74f5064398929fa4a58c46b60031ae3e0788e7e2e9294b06e0a82978f22ad502";
+        string
+            memory hashString3 = "0x72d7a3f1e9fa3953b9dfa6828dd4d4068abbe2041e121a61f102e1f7f9603d2a";
 
         bytes32 hashResult1 = StringUtils.hexToBytes32(hashString1);
         bytes32 hashResult2 = StringUtils.hexToBytes32(hashString2);
@@ -195,19 +211,25 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         address validator = 0x756e0562323ADcDA4430d6cb456d9151f605290B;
 
         bytes memory calldata1 = abi.encodeWithSignature(
-            "swapOwner(address,address,address)", address(1), owner, newOwner
+            "swapOwner(address,address,address)",
+            address(1),
+            owner,
+            newOwner
         );
         bytes memory recoveryData1 = abi.encode(account, calldata1);
         bytes32 recoveryDataHash1 = keccak256(recoveryData1);
 
-        bytes memory calldata2 = abi.encodeWithSignature("changeOwner(address)", newOwner);
+        bytes memory calldata2 = abi.encodeWithSignature(
+            "changeOwner(address)",
+            newOwner
+        );
         bytes memory recoveryData2 = abi.encode(validator, calldata2);
         bytes32 recoveryDataHash2 = keccak256(recoveryData2);
 
-        string memory hashString1 =
-            "0x268857b2318fd7eaa7e5be744cc041d64415d2df4588e3d234e7335ede6593a5";
-        string memory hashString2 =
-            "0x6ac9d4f1b3c69064f3f728b53ed1d38c79462138b4b03d5c2838a001233b7920";
+        string
+            memory hashString1 = "0x268857b2318fd7eaa7e5be744cc041d64415d2df4588e3d234e7335ede6593a5";
+        string
+            memory hashString2 = "0x6ac9d4f1b3c69064f3f728b53ed1d38c79462138b4b03d5c2838a001233b7920";
 
         bytes32 hashResult1 = StringUtils.hexToBytes32(hashString1);
         bytes32 hashResult2 = StringUtils.hexToBytes32(hashString2);
@@ -217,10 +239,11 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
     }
 
     function test_HexToBytes32_MaximumValue() public pure {
-        bytes32 maxBytes32 =
-            bytes32(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
-        string memory maxHashString =
-            "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        bytes32 maxBytes32 = bytes32(
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        );
+        string
+            memory maxHashString = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
         bytes32 result = StringUtils.hexToBytes32(maxHashString);
 

--- a/packages/contracts/test/libraries/StringUtils/fuzz/StringUtils_fuzz_hexToBytes.t.sol
+++ b/packages/contracts/test/libraries/StringUtils/fuzz/StringUtils_fuzz_hexToBytes.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import {console} from "forge-std/console.sol";
 import {StringUtils} from "src/libraries/StringUtils.sol";
 import {StructHelper} from "../../../helpers/StructHelper.sol";
 

--- a/packages/contracts/test/libraries/StringUtils/fuzz/StringUtils_fuzz_hexToBytes32.t.sol
+++ b/packages/contracts/test/libraries/StringUtils/fuzz/StringUtils_fuzz_hexToBytes32.t.sol
@@ -5,25 +5,29 @@ import { StringUtils } from "src/libraries/StringUtils.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { StructHelper } from "../../../helpers/StructHelper.sol";
 
+// Currently, tests in this contract are disabled on zkSync 
+// due to LLVM issues with Strings and StringUtils libraries
 contract StringUtils_HexToBytes32_Fuzz_Test is StructHelper {
     using Strings for uint256;
 
     function setUp() public override {
         super.setUp();
     }
+    
+    function testFuzz_hexToBytes32_ComputesExpectedHash(bytes32 expectedHash) public {
+        skipIfZkSync();
 
-    function testFuzz_hexToBytes32_ComputesExpectedHash(bytes32 expectedHash) public pure {
         string memory hashString = uint256(expectedHash).toHexString(32);
-
         bytes32 hashResult = StringUtils.hexToBytes32(hashString);
 
         assertEq(hashResult, expectedHash);
     }
 
-    function testFuzz_hexToBytes32_ComputesExpectedAddressHash(address addressToHash) public pure {
+    function testFuzz_hexToBytes32_ComputesExpectedAddressHash(address addressToHash) public {
+        skipIfZkSync();
+
         bytes32 expectedHash = keccak256(abi.encodePacked(addressToHash));
         string memory hashString = uint256(expectedHash).toHexString(32);
-
         bytes32 hashResult = StringUtils.hexToBytes32(hashString);
 
         assertEq(hashResult, expectedHash);
@@ -31,8 +35,9 @@ contract StringUtils_HexToBytes32_Fuzz_Test is StructHelper {
 
     function testFuzz_hexToBytes32_ComputesExpectedCalldataHash(bytes memory calldataToHash)
         public
-        pure
     {
+        skipIfZkSync();
+
         bytes32 expectedHash = keccak256(calldataToHash);
         string memory hashString = uint256(expectedHash).toHexString(32);
 


### PR DESCRIPTION
1. Fixed LLVM compiler issues which happened due to conflicting strings.sol and Strings.sol in StringUtils test cases.
2. Update some test cases to fit to era-test-node styles
3. Update yarn zkbuild and yarn zktest commands in package.json
4. Update README.md

Finally all unit tests has been passed by using era-test-node right now.
